### PR TITLE
Allow get requests with different host_name.

### DIFF
--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -17,11 +17,12 @@ class UrlboxClient:
         Required for authenticated requests.
     """
 
-    URLBOX_BASE_API_URL = "https://api.urlbox.io/v1/"
+    BASE_API_URL = "https://api.urlbox.io/v1/"
 
-    def __init__(self, *, api_key, api_secret=None):
+    def __init__(self, *, api_key, api_secret=None, api_host_name=None):
         self.api_key = api_key
         self.api_secret = api_secret
+        self.base_api_url = self._init_base_api_url(api_host_name)
 
     def get(self, options):
         """
@@ -46,15 +47,29 @@ class UrlboxClient:
         if not self._valid_url(url_stripped):
             raise InvalidUrlException(url_stripped)
 
+        request_url = (
+            f"{self.base_api_url}"
+            f"{self.api_key}/{format}"
+            f"?url={self._parsed_url(url_stripped)}"
+            f"&{urllib.parse.urlencode(options)}"
+        )
+
         return requests.get(
             (
-                f"{self.URLBOX_BASE_API_URL}"
+                f"{self.base_api_url}"
                 f"{self.api_key}/{format}"
                 f"?{urllib.parse.urlencode(options)}"
             )
         )
 
     # private
+
+    def _init_base_api_url(self, api_host_name):
+        if api_host_name is None:
+            return self.BASE_API_URL
+        else:
+            return f"https://{api_host_name}/"
+
     def _parsed_url(self, url):
         return urllib.parse.quote(url)
 


### PR DESCRIPTION
#### What's this PR do?
Allows get requests with different host_name.

#### Background context
Some users are using "api-eu.urlbox.io" and "api-direct.urlbox.io", rather than the default: "api.urlbox.io".

#### Where should the reviewer start?
https://github.com/urlbox/urlbox-python/pull/11/files#diff-b09270ef6a40cb00ca6062d20810febfc7dc4a2615b96e5efb5bad036624f774R25

and

https://github.com/urlbox/urlbox-python/pull/11/files#diff-b09270ef6a40cb00ca6062d20810febfc7dc4a2615b96e5efb5bad036624f774R67-R71

```python
def _init_base_api_url(self, api_host_name):
        if api_host_name is None:
            return self.BASE_API_URL
        else:
            return f"https://{api_host_name}/"
```

This checks if the user has passed in a value for the api_host_name parameter when initialising the client.
If they have, we use that url, else we use the default: BASE_API_URL = "https://api.urlbox.io/v1/"

