### PR TITLE
Prepend http:// to schema-less URLs before URL validation.

### DIFF
--- a/tests/test_urlbox_client.py
+++ b/tests/test_urlbox_client.py
@@ -179,6 +179,52 @@ def test_get_successful_white_space_url():
             assert isinstance(response.content, bytes)
 
 
+def test_get_successful_missing_schema_url():
+    api_key = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+
+    url = "twitter.com"
+    url_with_schema = f"http://{url}"
+
+    options = {
+        "url": url_with_schema,
+        "format": format,
+        "full_page": random.choice([True, False]),
+        "width": fake.random_int(),
+    }
+
+    options_parsed = options.copy()
+    options_parsed["url"] = url
+
+    urlbox_request_url = (
+        f"{UrlboxClient.BASE_API_URL}"
+        f"{api_key}/{format}"
+        f"?{urllib.parse.urlencode(options)}"
+    )
+
+    urlbox_client = UrlboxClient(api_key=api_key)
+
+    with requests_mock.Mocker() as requests_mocker:
+        with open(
+            "tests/files/urlbox_screenshot.png", "rb"
+        ) as urlbox_screenshot:
+            requests_mocker.get(
+                urlbox_request_url,
+                content=urlbox_screenshot.read(),
+                headers={"content-type": f"image/{format}"},
+            )
+
+            response = urlbox_client.get(options)
+
+            assert response.status_code == 200
+            assert format in response.headers["Content-Type"]
+            assert isinstance(response, requests.models.Response)
+            assert isinstance(response.content, bytes)
+
+
 def test_get_invalid_url():
     format = random.choice(
         ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -47,11 +47,12 @@ class UrlboxClient:
         url = options["url"]
 
         url_stripped = url.strip()
-        options["url"] = url_stripped
+        url_parsed = self._append_schema(url_stripped)
+        options["url"] = url_parsed
         url_encoded_options = urllib.parse.urlencode(options)
 
-        if not self._valid_url(url_stripped):
-            raise InvalidUrlException(url_stripped)
+        if not self._valid_url(url_parsed):
+            raise InvalidUrlException(url_parsed)
 
         if to_string:
             return (
@@ -91,9 +92,11 @@ class UrlboxClient:
         else:
             return f"https://{api_host_name}/"
 
-    def _parsed_url(self, url):
-        # TODO: if not url.startswith("http"): url = "http://" + url
-        pass
+    def _append_schema(self, url):
+        if not url.startswith("http"):
+            return f"http://{url}"
+        else:
+            return url
 
     def _token(self, url_encoded_options):
         return (


### PR DESCRIPTION
#### What's this PR do?
Prepends http:// to schema-less URLs before URL validation.

#### Background context
This allows a more liberal / forgiving interface for users to request
eg: twitter.com, without the request failing URL validation.

