### PR TITLE
Add simple HEAD request to UrlboxClient.

### DIFF
--- a/tests/test_urlbox_client.py
+++ b/tests/test_urlbox_client.py
@@ -288,5 +288,41 @@ def test_get_with_different_host_name():
             assert isinstance(response.content, bytes)
 
 
-# TODO:
-# Test invalid API key
+def test_head_request():
+    api_key = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+    url = fake.url()
+
+    options = {
+        "url": url,
+        "format": format,
+        "full_page": random.choice([True, False]),
+        "width": fake.random_int(),
+    }
+
+    urlbox_request_url = (
+        f"{UrlboxClient.BASE_API_URL}"
+        f"{api_key}/{format}"
+        f"?{urllib.parse.urlencode(options)}"
+    )
+
+    urlbox_client = UrlboxClient(api_key=api_key)
+
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.head(
+            urlbox_request_url,
+            content=b"",
+            headers={"content-type": f"image/{format}"},
+        )
+
+        response = urlbox_client.head(options)
+
+        assert response.status_code == 200
+        assert format in response.headers["Content-Type"]
+        assert isinstance(response, requests.models.Response)
+        assert isinstance(response.content, bytes)
+        assert len(response.content) == 0
+

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -66,6 +66,41 @@ class UrlboxClient:
         else:
             return self._get_authenticated(format, url_encoded_options)
 
+    def head(self, options):
+        """
+            Make simple head request to Urlbox API
+
+            To get the response status/headers without pulling down the full response body.
+
+            :param options: dictionary containing all of the options you want to set.
+            eg: {"url": "http://example.com/", "format": "png", "full_page": True, "width": 300}
+
+            format: can be either "png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html".
+
+            Example: urlbox_client.get({"url": "http://example.com/", "format": "png", "full_page": True, "width": 300})
+            API example: https://urlbox.io/docs/getting-started
+            Full options reference: https://urlbox.io/docs/options
+        """
+
+        format = options["format"]
+        url = options["url"]
+
+        url_stripped = url.strip()
+        url_parsed = self._prepend_schema(url_stripped)
+        options["url"] = url_parsed
+        url_encoded_options = urllib.parse.urlencode(options)
+
+        if not self._valid_url(url_parsed):
+            raise InvalidUrlException(url_parsed)
+
+        return requests.head(
+            (
+                f"{self.base_api_url}"
+                f"{self.api_key}/{format}"
+                f"?{url_encoded_options}"
+            )
+        )
+
     # private
 
     def _get_authenticated(self, format, url_encoded_options):


### PR DESCRIPTION
#### What's this PR do?
Adds simple HEAD request to UrlboxClient.

#### Background context
As Urlbox also accepts HEAD requests if you just want to get the
response status/headers without pulling down the full response body.

So this provides parity with the API.

#### Where should the reviewer start?

#### How should this be manually tested?
```python
api_key = "XXXXXXX"
api_secret = "XXXXXXX"

urlbox_client = UrlboxClient(api_key=api_key, api_secret=api_secret)
response = urlbox_client.head({"url": "twitter.com/", "full_page": True, "format": "png"})
```
