### PR TITLE
Allow users to request a render of html, not just a url.

### DIFF
--- a/tests/test_urlbox_client.py
+++ b/tests/test_urlbox_client.py
@@ -325,6 +325,68 @@ def test_get_with_different_host_name():
             assert isinstance(response.content, bytes)
 
 
+def test_get_successful_with_html_not_url():
+    api_key = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+
+    html = "<html><head></head><body><h1>TEST</h1></body></html>"
+
+    options = {"html": html, "format": format}
+
+    urlbox_request_url = (
+        f"{UrlboxClient.BASE_API_URL}"
+        f"{api_key}/{format}"
+        f"?{urllib.parse.urlencode(options)}"
+    )
+
+    urlbox_client = UrlboxClient(api_key=api_key)
+
+    with requests_mock.Mocker() as requests_mocker:
+        with open(
+            "tests/files/urlbox_screenshot.png", "rb"
+        ) as urlbox_screenshot:
+            requests_mocker.get(
+                urlbox_request_url,
+                content=urlbox_screenshot.read(),
+                headers={"content-type": f"image/{format}"},
+            )
+
+            response = urlbox_client.get(options)
+
+            assert response.status_code == 200
+            assert format in response.headers["Content-Type"]
+            assert isinstance(response, requests.models.Response)
+            assert isinstance(response.content, bytes)
+
+
+def test_get_unsuccessful_without_html_not_url():
+    api_key = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+
+    options = {"format": format}
+
+    urlbox_request_url = (
+        f"{UrlboxClient.BASE_API_URL}"
+        f"{api_key}/{format}"
+        f"?{urllib.parse.urlencode(options)}"
+    )
+
+    urlbox_client = UrlboxClient(api_key=api_key)
+
+    with pytest.raises(KeyError) as missing_key_exception:
+        urlbox_client.get(options)
+
+    assert "Missing 'url' or 'html' key in options" in str(
+        missing_key_exception.value
+    )
+
+
 def test_head_request():
     api_key = fake.pystr()
 

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -43,16 +43,23 @@ class UrlboxClient:
             Full options reference: https://urlbox.io/docs/options
         """
 
+        if "html" not in options and "url" not in options:
+            raise KeyError("Missing 'url' or 'html' key in options")
+
+        if "url" in options:
+            url = options["url"]
+
+            url_stripped = url.strip()
+            url_parsed = self._prepend_schema(url_stripped)
+            options["url"] = url_parsed
+
+            if not self._valid_url(url_parsed):
+                raise InvalidUrlException(url_parsed)
+
         format = options.get("format", "png")
-        url = options["url"]
+        options["format"] = format
 
-        url_stripped = url.strip()
-        url_parsed = self._prepend_schema(url_stripped)
-        options["url"] = url_parsed
         url_encoded_options = urllib.parse.urlencode(options)
-
-        if not self._valid_url(url_parsed):
-            raise InvalidUrlException(url_parsed)
 
         if to_string:
             return (
@@ -82,16 +89,23 @@ class UrlboxClient:
             Full options reference: https://urlbox.io/docs/options
         """
 
-        format = options["format"]
-        url = options["url"]
+        if "html" not in options and "url" not in options:
+            raise KeyError("Missing 'url' or 'html' key in options")
 
-        url_stripped = url.strip()
-        url_parsed = self._prepend_schema(url_stripped)
-        options["url"] = url_parsed
+        if "url" in options:
+            url = options["url"]
+
+            url_stripped = url.strip()
+            url_parsed = self._prepend_schema(url_stripped)
+            options["url"] = url_parsed
+
+            if not self._valid_url(url_parsed):
+                raise InvalidUrlException(url_parsed)
+
+        format = options.get("format", "png")
+        options["format"] = format
+
         url_encoded_options = urllib.parse.urlencode(options)
-
-        if not self._valid_url(url_parsed):
-            raise InvalidUrlException(url_parsed)
 
         return requests.head(
             (


### PR DESCRIPTION
#### What's this PR do?
Allow users to request a render of html, not just a url.

#### Background context
This is something the API offers so we need to implement this option too.

If neither a url or html key, value entry exists in the options dictionary, a KeyError is raised.
