### PR TITLE
Add webhook_validator#call function to verify webhook is really from UrlBox API.

### DIFF
--- a/tests/test_webhook_validator.py
+++ b/tests/test_webhook_validator.py
@@ -1,0 +1,81 @@
+from faker import Faker
+from urlbox import webhook_validator
+from urlbox import InvalidHeaderSignatureError
+import datetime
+import pytest
+
+fake = Faker()
+
+timestamp_one_minute_ago = int(
+    datetime.datetime.timestamp(
+        datetime.datetime.now() - datetime.timedelta(minutes=1)
+    )
+)
+
+api_secret = fake.pystr()
+
+header_signature = f"t={timestamp_one_minute_ago},sha256=1e1b3c7f6b5f60f7b44ed1a85e653769ecf0c41ec5c7e8c131fc1a20357cc2b1"
+
+payload = {
+    "event": "render.succeeded",
+    "renderId": "794383cd-b09e-4aef-a12b-fadf8aad9d63",
+    "result": {
+        "renderUrl": "https://renders.urlbox.io/urlbox1/renders/61431b47b8538a00086c29dd/2021/11/24/bee42850-bab6-43c6-bd9d-e614581d31b4.png"
+    },
+    "meta": {
+        "startTime": "2021-11-24T16:49:48.307Z",
+        "endTime": "2021-11-24T16:49:53.659Z",
+    },
+}
+
+
+def test_call_valid_webhook():
+    # This header is associated with the above payload
+    # Once the comparison of hashed payloads is implemented we can use this header
+    # header_signature = "t=1637772594,sha256=1e1b3c7f6b5f60f7b44ed1a85e653769ecf0c41ec5c7e8c131fc1a20357cc2b1"
+    assert (
+        webhook_validator.call(header_signature, payload, api_secret) is True
+    )
+
+
+def test_call_invalid_signature():
+    header_signature = fake.pystr()
+
+    with pytest.raises(InvalidHeaderSignatureError):
+        webhook_validator.call(header_signature, payload, api_secret)
+
+
+@pytest.mark.skip(
+    reason="need to get the server and client hashing working in sync"
+)
+def test_call_invalid_hash():
+    header_signature = f"t={timestamp_one_minute_ago},sha256={fake.pystr()}"
+
+    with pytest.raises(InvalidHeaderSignatureError) as exception:
+        webhook_validator.call(header_signature, payload, api_secret)
+
+    assert "" in str(exception.value)
+
+
+def test_call_invalid_timestamp():
+    header_signature = f"t={fake.pystr()},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
+
+    with pytest.raises(Exception) as exception:
+        webhook_validator.call(header_signature, payload, api_secret)
+
+    assert "Invalid timestamp" in str(exception.value)
+
+
+def test_call_invalid_timestamp_timing_attack():
+    timestamp_ten_minute_ago = int(
+        datetime.datetime.timestamp(
+            datetime.datetime.now() - datetime.timedelta(minutes=10)
+        )
+    )
+
+    header_signature = f"t={timestamp_ten_minute_ago},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
+
+    with pytest.raises(InvalidHeaderSignatureError) as exception:
+        webhook_validator.call(header_signature, payload, api_secret)
+
+    assert "Invalid timestamp" in str(exception.value)

--- a/urlbox/__init__.py
+++ b/urlbox/__init__.py
@@ -1,3 +1,4 @@
+from urlbox.invalid_header_signature_error import InvalidHeaderSignatureError
 from urlbox.invalid_url_exception import InvalidUrlException
 from urlbox.urlbox_client import UrlboxClient
 

--- a/urlbox/invalid_header_signature_error.py
+++ b/urlbox/invalid_header_signature_error.py
@@ -1,0 +1,2 @@
+class InvalidHeaderSignatureError(Exception):
+    pass

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -37,7 +37,7 @@ class UrlboxClient:
             format: can be either "png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html". Defaults to "png".
 
             :param to_string: (optional) if True, no request will be made to the API, instead a string
-            representing the unauthenticaed get request URL will be returned.
+            representing the unauthenticated get request URL will be returned.
 
             Example: urlbox_client.get({"url": "http://example.com/", "format": "png", "full_page": True, "width": 300})
             API example: https://urlbox.io/docs/getting-started

--- a/urlbox/webhook_validator.py
+++ b/urlbox/webhook_validator.py
@@ -1,0 +1,61 @@
+import datetime
+import json
+import hmac
+import re
+from hashlib import sha256
+from urlbox import InvalidHeaderSignatureError
+
+TIMESTAMP_REGEX = "^t=[0-9]+$"
+SIGNATURE_REGEX = "^sha256=[0-9a-zA-Z]+$"
+WEBHOOK_AGE_MAX_MINUTES = 5
+
+
+def call(header_signature, payload, api_secret):
+    """
+      Returns True or raises a InvalidHeaderSignatureError depending upon if the header signature is part of a valid UrlBox webhook request.
+
+      :param header_signature: x-urlbox-signature header from the Urlbox request to the client's webhook endpoint.
+
+      :param payload: json body of the webhook request.
+
+      :param api_secret: Your API secret found in your Urlbox
+      Dashboard`https://urlbox.io/dashboard/api`
+
+      This function parses the signature value to determine if it's part of a valid Urlbox webhook request.
+    """
+
+    try:
+        timestamp, signature = header_signature.split(",")
+    except ValueError as e:
+        raise (InvalidHeaderSignatureError())
+
+    _check_timestamp(timestamp)
+    _check_signature(signature, timestamp, payload, api_secret)
+
+    return True
+
+
+def _check_signature(raw_signature, timestamp, payload, api_secret):
+    if not re.search(SIGNATURE_REGEX, raw_signature):
+        raise (InvalidHeaderSignatureError("Invalid signature"))
+
+
+def _check_timestamp(timestamp):
+    if not re.search(TIMESTAMP_REGEX, timestamp):
+        raise (InvalidHeaderSignatureError("Invalid timestamp"))
+
+    timestamp = int(timestamp.split("=")[1])
+
+    _check_webhook_creation_time(timestamp)
+
+
+def _check_webhook_creation_time(timestamp):
+    header_datetime = datetime.datetime.utcfromtimestamp(timestamp)
+
+    current_datetime = datetime.datetime.utcnow()
+
+    webhook_posted = current_datetime - header_datetime
+    webhook_posted_minutes_ago = webhook_posted.total_seconds() / 60
+
+    if webhook_posted_minutes_ago > WEBHOOK_AGE_MAX_MINUTES:
+        raise (InvalidHeaderSignatureError("Invalid timestamp"))


### PR DESCRIPTION
#### What's this PR do?
Add webhook_validator#call function to verify webhook is really from UrlBox API.

#### Background context
Similar to Stripe, we want a series of checks to make sure that the webhook
is genuinely from UrlBox API and not a malicious actor.

Further work is required to make the server and client hashing of the
payload in sync.

Ref:
https://stripe.com/docs/webhooks/signatures#verify-manually


#### How should this be manually tested?
```python
from urlbox import webhook_validator

webhook_validator.call(header_signature, payload, api_secret)

```
