### PR TITLE
Add delete method to UrlboxClient.

### DIFF
--- a/tests/test_urlbox_client.py
+++ b/tests/test_urlbox_client.py
@@ -438,6 +438,37 @@ def test_get_unsuccessful_without_html_not_url():
     )
 
 
+# DELETE
+def test_delete_request():
+    api_key = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+    url = fake.url()
+
+    options = {"url": url, "format": format}
+
+    urlbox_request_url = (
+        f"{UrlboxClient.BASE_API_URL}"
+        f"{api_key}/{format}"
+        f"?{urllib.parse.urlencode(options)}"
+    )
+
+    urlbox_client = UrlboxClient(api_key=api_key)
+
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.delete(
+            urlbox_request_url, headers={"content-type": f"image/{format}"}
+        )
+
+        response = urlbox_client.delete(options)
+
+        assert response.status_code == 200
+        assert format in response.headers["Content-Type"]
+        assert isinstance(response, requests.models.Response)
+
+
 # HEAD
 def test_head_request():
     api_key = fake.pystr()

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -65,6 +65,33 @@ class UrlboxClient:
         else:
             return self._get_authenticated(format, url_encoded_options)
 
+    def delete(self, options):
+        """
+            Deletes the screenshot from the cache.
+
+            :param options: dictionary containing url of the site the screneshot has captured
+            and the format of the original screenshot eg: png, jpg, etc
+            eg: {"url": "http://example.com/", "format": "png"}
+        """
+
+        self._raise_key_error_if_missing_required_keys(options)
+
+        if "url" in options:
+            options["url"] = self._process_url(options["url"])
+
+        format = options.get("format", "png")
+        options["format"] = format
+
+        url_encoded_options = urllib.parse.urlencode(options)
+
+        return requests.delete(
+            (
+                f"{self.base_api_url}"
+                f"{self.api_key}/{format}"
+                f"?{url_encoded_options}"
+            )
+        )
+
     def head(self, options):
         """
             Make simple head request to Urlbox API


### PR DESCRIPTION
#### What's this PR do?
Adds delete method to UrlboxClient.

#### Background context
This will delete the screenshot associated with the url from the cache.

Has the same signature as the GET request.

http://api.urlbox.io/v1/api_key/format?url=https://example.com
