### PR TITLE
Add slightly stricter regex on validating sha256 signature.

### DIFF
--- a/tests/test_webhook_validator.py
+++ b/tests/test_webhook_validator.py
@@ -45,16 +45,13 @@ def test_call_invalid_signature():
         webhook_validator.call(header_signature, payload, api_secret)
 
 
-@pytest.mark.skip(
-    reason="need to get the server and client hashing working in sync"
-)
 def test_call_invalid_hash():
     header_signature = f"t={timestamp_one_minute_ago},sha256={fake.pystr()}"
 
     with pytest.raises(InvalidHeaderSignatureError) as exception:
         webhook_validator.call(header_signature, payload, api_secret)
 
-    assert "" in str(exception.value)
+    assert "Invalid signature" in str(exception.value)
 
 
 def test_call_invalid_timestamp():

--- a/urlbox/webhook_validator.py
+++ b/urlbox/webhook_validator.py
@@ -5,8 +5,8 @@ import re
 from hashlib import sha256
 from urlbox import InvalidHeaderSignatureError
 
+SIGNATURE_REGEX = "^sha256=[0-9a-zA-Z]{40,}$"
 TIMESTAMP_REGEX = "^t=[0-9]+$"
-SIGNATURE_REGEX = "^sha256=[0-9a-zA-Z]+$"
 WEBHOOK_AGE_MAX_MINUTES = 5
 
 


### PR DESCRIPTION
#### What's this PR do?
Adds slightly stricter regex on validating sha256 signature.

#### Background context
Not all of the webhook_validator was covered by tests.

The check for an invalid sha256 signature was set to pending as we
need to implement the more thorough server generated sha256 signature
vs the client generated sha256 signature.

However this pending test was the only test testing the raising of the
invalid signature exception:
```
if not re.search(SIGNATURE_REGEX, raw_signature):
    raise (InvalidHeaderSignatureError("Invalid signature"))
```

By making the regex checking the sha256 signature stricter, by requiring
at least 40 characters in the signature, we can now test this area of the
code, rather than have the test set to pending.
