### PR TITLE
Validate webhook header signature by creating the same hash of the payload as the server.

### DIFF
--- a/tests/test_webhook_validator.py
+++ b/tests/test_webhook_validator.py
@@ -2,7 +2,10 @@ from faker import Faker
 from urlbox import webhook_validator
 from urlbox import InvalidHeaderSignatureError
 import datetime
+import json
+import hmac
 import pytest
+from hashlib import sha256
 
 fake = Faker()
 
@@ -12,7 +15,7 @@ timestamp_one_minute_ago = int(
     )
 )
 
-api_secret = fake.pystr()
+webhook_secret = fake.pystr()
 
 header_signature = f"t={timestamp_one_minute_ago},sha256=1e1b3c7f6b5f60f7b44ed1a85e653769ecf0c41ec5c7e8c131fc1a20357cc2b1"
 
@@ -30,26 +33,48 @@ payload = {
 
 
 def test_call_valid_webhook():
-    # This header is associated with the above payload
-    # Once the comparison of hashed payloads is implemented we can use this header
-    # header_signature = "t=1637772594,sha256=1e1b3c7f6b5f60f7b44ed1a85e653769ecf0c41ec5c7e8c131fc1a20357cc2b1"
+    # Dynamically generate header signature to make the crypto comparision pass
+    payload_json_string = json.dumps(payload, separators=(",", ":"))
+
+    signature_generated = hmac.new(
+        webhook_secret.encode("utf-8"),
+        msg=f"{timestamp_one_minute_ago}.{payload_json_string}".encode(
+            "utf-8"
+        ),
+        digestmod=sha256,
+    ).hexdigest()
+
+    header_signature = (
+        f"t={timestamp_one_minute_ago},sha256={signature_generated}"
+    )
+
     assert (
-        webhook_validator.call(header_signature, payload, api_secret) is True
+        webhook_validator.call(header_signature, payload, webhook_secret)
+        is True
     )
 
 
 def test_call_invalid_signature():
     header_signature = fake.pystr()
 
-    with pytest.raises(InvalidHeaderSignatureError):
-        webhook_validator.call(header_signature, payload, api_secret)
+    with pytest.raises(InvalidHeaderSignatureError) as exception:
+        webhook_validator.call(header_signature, payload, webhook_secret)
 
 
-def test_call_invalid_hash():
+def test_call_invalid_hash_mismatch():
+    header_signature = f"t={timestamp_one_minute_ago},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
+
+    with pytest.raises(InvalidHeaderSignatureError) as exception:
+        webhook_validator.call(header_signature, payload, webhook_secret)
+
+    assert "Invalid signature" in str(exception.value)
+
+
+def test_call_invalid_hash_regex_catch():
     header_signature = f"t={timestamp_one_minute_ago},sha256={fake.pystr()}"
 
     with pytest.raises(InvalidHeaderSignatureError) as exception:
-        webhook_validator.call(header_signature, payload, api_secret)
+        webhook_validator.call(header_signature, payload, webhook_secret)
 
     assert "Invalid signature" in str(exception.value)
 
@@ -58,7 +83,7 @@ def test_call_invalid_timestamp():
     header_signature = f"t={fake.pystr()},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
 
     with pytest.raises(Exception) as exception:
-        webhook_validator.call(header_signature, payload, api_secret)
+        webhook_validator.call(header_signature, payload, webhook_secret)
 
     assert "Invalid timestamp" in str(exception.value)
 
@@ -73,6 +98,6 @@ def test_call_invalid_timestamp_timing_attack():
     header_signature = f"t={timestamp_ten_minute_ago},sha256=930ee08957512f247e289703ac951fc60da1e2d12919bfd518d90513b0687ee0"
 
     with pytest.raises(InvalidHeaderSignatureError) as exception:
-        webhook_validator.call(header_signature, payload, api_secret)
+        webhook_validator.call(header_signature, payload, webhook_secret)
 
     assert "Invalid timestamp" in str(exception.value)

--- a/urlbox/webhook_validator.py
+++ b/urlbox/webhook_validator.py
@@ -10,7 +10,7 @@ TIMESTAMP_REGEX = "^t=[0-9]+$"
 WEBHOOK_AGE_MAX_MINUTES = 5
 
 
-def call(header_signature, payload, api_secret):
+def call(header_signature, payload, webhook_secret):
     """
       Returns True or raises a InvalidHeaderSignatureError depending upon if the header signature is part of a valid UrlBox webhook request.
 
@@ -18,7 +18,7 @@ def call(header_signature, payload, api_secret):
 
       :param payload: json body of the webhook request.
 
-      :param api_secret: Your API secret found in your Urlbox
+      :param webhook_secret: Your webhook secret found in your Urlbox (NB: NOT the api secret - that's a different secret)
       Dashboard`https://urlbox.io/dashboard/api`
 
       This function parses the signature value to determine if it's part of a valid Urlbox webhook request.
@@ -30,13 +30,27 @@ def call(header_signature, payload, api_secret):
         raise (InvalidHeaderSignatureError())
 
     _check_timestamp(timestamp)
-    _check_signature(signature, timestamp, payload, api_secret)
+    _check_signature(signature, timestamp, payload, webhook_secret)
 
     return True
 
 
-def _check_signature(raw_signature, timestamp, payload, api_secret):
+def _check_signature(raw_signature, timestamp, payload, webhook_secret):
     if not re.search(SIGNATURE_REGEX, raw_signature):
+        raise (InvalidHeaderSignatureError("Invalid signature"))
+
+    signature_webhook = raw_signature.split("=")[1]
+    timestamp = int(timestamp.split("=")[1])
+
+    payload_json_string = json.dumps(payload, separators=(",", ":"))
+
+    signature_generated = hmac.new(
+        webhook_secret.encode("utf-8"),
+        msg=f"{timestamp}.{payload_json_string}".encode("utf-8"),
+        digestmod=sha256,
+    ).hexdigest()
+
+    if not hmac.compare_digest(signature_generated, signature_webhook):
         raise (InvalidHeaderSignatureError("Invalid signature"))
 
 


### PR DESCRIPTION
#### What's this PR do?
Validates the webhook header signature by creating the same hash of the payload as the server.

#### Background context
The server creates the signature by hashing the response payload using the
Urlbox webhook secret (NOT the API secret! - different thing).

We need to recreate the same signature from the webhook's payload and
make sure they match to prevent any malicious actors claiming to be
posting from Urlbox.

Ref:
https://github.com/stripe/stripe-python/blob/master/stripe/webhook.py
