### PR TITLE
Bump package version to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="urlbox",
-    version="0.1.0",
+    version="1.0.0",
     author="Alan Donohoe",
     author_email="alan@urlbox.io",
     description="Official Python client for the Ulrbox API",


### PR DESCRIPTION
#### What's this PR do?
Bumps package version to 1.0.0

#### Background context
The draft package (v 0.1.0) has been fully QA'd by installing it on a
completely separate machine to the machine it was developed on and all
public methods are working as expected.

So now is the time for the official release!
