### PR TITLE
Extract Out Urlbox URL-as-a-String generation to its own function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ First, grab your Urlbox API key* found in your <a href="https://urlbox.io/dashbo
 *\* and grab your API secret - if you want to make authenticated requests. Requests will be automatically authenticated when you supply YOUR_API_SECRET.
 So you really should.*
 
+### Quick Start:  Generate a Screenshot URL
+For use directly in HTML templates, the browser etc.
+
+In your python_code.py:
+```python
+from urlbox import UrlboxClient
+
+# Initialise the UrlboxClient (YOUR_API_SECRET is optional but recommended)
+urlbox_client = UrlboxClient(api_key="YOUR_API_KEY", api_secret="YOUR_API_SECRET")
+
+screenshot_url = urlbox_client.generate_url({"url": "http://example.com/"})
+```
+
+In your html template:
+```html
+<img src="{{  screenshot_url }}"/>
+```
+
 ###  Quick Start: Quickly Get a Screenshot of a URL
 
 ```python

--- a/tests/test_urlbox_client.py
+++ b/tests/test_urlbox_client.py
@@ -138,53 +138,6 @@ def test_get_successful_authenticated():
             assert isinstance(response.content, bytes)
 
 
-# providing just the api_key
-def test_get_successful_as_str():
-    api_key = fake.pystr()
-
-    format = random.choice(
-        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
-    )
-    url = fake.url()
-
-    options = {
-        "url": url,
-        "format": format,
-        "full_page": random.choice([True, False]),
-        "width": fake.random_int(),
-    }
-
-    urlbox_client = UrlboxClient(api_key=api_key)
-
-    response = urlbox_client.get(options, to_string=True)
-
-    assert isinstance(response, str)
-
-
-def test_get_successful_as_str_with_api_secret():
-    api_key = fake.pystr()
-    api_secret = fake.pystr()
-
-    format = random.choice(
-        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
-    )
-    url = fake.url()
-
-    options = {
-        "url": url,
-        "format": format,
-        "full_page": random.choice([True, False]),
-        "width": fake.random_int(),
-    }
-
-    urlbox_client = UrlboxClient(api_key=api_key, api_secret=api_secret)
-    response = urlbox_client.get(options, to_string=True)
-
-    assert isinstance(response, str)
-    # It still returns the unautenticated get url
-    assert api_secret not in response
-
-
 def test_get_with_header_array_in_options():
     api_key = fake.pystr()
 
@@ -751,3 +704,49 @@ def test_post_request_unsuccessful_missing_api_secret():
         in str(ex.value)
     )
 
+
+# Test generate_url
+def test_generate_url_without_api_secret():
+    api_key = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+    url = fake.url()
+
+    options = {
+        "url": url,
+        "format": format,
+        "full_page": random.choice([True, False]),
+        "width": fake.random_int(),
+    }
+
+    urlbox_client = UrlboxClient(api_key=api_key)
+
+    urlbox_url = urlbox_client.generate_url(options)
+
+    assert isinstance(urlbox_url, str)
+
+
+def test_get_successful_as_str_with_api_secret():
+    api_key = fake.pystr()
+    api_secret = fake.pystr()
+
+    format = random.choice(
+        ["png", "jpg", "jpeg", "avif", "webp", "pdf", "svg", "html"]
+    )
+    url = fake.url()
+
+    options = {
+        "url": url,
+        "format": format,
+        "full_page": random.choice([True, False]),
+        "width": fake.random_int(),
+    }
+
+    urlbox_client = UrlboxClient(api_key=api_key, api_secret=api_secret)
+    urlbox_url = urlbox_client.generate_url(options)
+
+    assert isinstance(urlbox_url, str)
+    # It doesn't leak the api_secret (uses the tokenised options instead)
+    assert api_secret not in urlbox_url

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -45,12 +45,7 @@ class UrlboxClient:
             Full options reference: https://urlbox.io/docs/options
         """
 
-        processed_options, format = self._process_options(options)
-
-        if self.api_secret is None:
-            return self._get_unauthenticated(format, processed_options)
-        else:
-            return self._get_authenticated(format, processed_options)
+        return requests.get(self.generate_url(options), timeout=100)
 
     def delete(self, options):
         """
@@ -170,22 +165,6 @@ class UrlboxClient:
             )
 
     # private
-
-    def _get_authenticated(self, format, options):
-        return requests.get(
-            (
-                f"{self.base_api_url}"
-                f"{self.api_key}/{self._token(options)}/{format}"
-                f"?{options}"
-            ),
-            timeout=100,
-        )
-
-    def _get_unauthenticated(self, format, options):
-        return requests.get(
-            (f"{self.base_api_url}{self.api_key}/{format}?{options}"),
-            timeout=100,
-        )
 
     def _init_base_api_url(self, api_host_name):
         if api_host_name is None:

--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -28,7 +28,7 @@ class UrlboxClient:
         self.api_secret = api_secret
         self.base_api_url = self._init_base_api_url(api_host_name)
 
-    def get(self, options, to_string=False):
+    def get(self, options):
         """
             Make simple get request to Urlbox API
 
@@ -46,13 +46,6 @@ class UrlboxClient:
         """
 
         processed_options, format = self._process_options(options)
-
-        if to_string:
-            return (
-                f"{self.base_api_url}"
-                f"{self.api_key}/{format}"
-                f"?{processed_options}"
-            )
 
         if self.api_secret is None:
             return self._get_unauthenticated(format, processed_options)
@@ -140,6 +133,41 @@ class UrlboxClient:
             json=json.loads(json.dumps(processed_options)),
             timeout=5,
         )
+
+    def generate_url(self, options):
+        """
+            Generate the Urlbox URL as a string for use directly in HTML templates, the browser etc.
+
+            :param options: dictionary containing all of the options you want to set.
+            eg: {"url": "http://example.com/", "format": "png", "full_page": True, "width": 300}
+
+            Example:
+            In your python_code.py:
+            # Initialise the UrlboxClient (YOUR_API_SECRET is optional but recommended)
+            urlbox_client = UrlboxClient(api_key="YOUR_API_KEY", api_secret="YOUR_API_SECRET")
+
+            screenshot_url = urlbox_client.generate_url({"url": "http://example.com/"})
+
+            In your html template:
+            <img src="{{  screenshot_url }}"/>
+
+            Full options reference: https://urlbox.io/docs/options
+        """
+
+        processed_options, format = self._process_options(options)
+
+        if self.api_secret is None:
+            return (
+                f"{self.base_api_url}"
+                f"{self.api_key}/{format}"
+                f"?{processed_options}"
+            )
+        else:
+            return (
+                f"{self.base_api_url}"
+                f"{self.api_key}/{self._token(processed_options)}/{format}"
+                f"?{processed_options}"
+            )
 
     # private
 


### PR DESCRIPTION
#### What's this PR do?
Extracts Out Urlbox URL-as-a-String generation to its own function.

#### Background context
This is an important use case and so deserves to be a primary feature/function.

It was previously shoehorned into the get method.

#### Where should the reviewer start?
https://github.com/urlbox/urlbox-python/pull/39/files#diff-b09270ef6a40cb00ca6062d20810febfc7dc4a2615b96e5efb5bad036624f774R132-R153

#### How should this be manually tested?

In your python_code.py:
```python
import urlbox_url

# Initialise the UrlboxClient (YOUR_API_SECRET is optional but recommended)
urlbox_client = UrlboxClient(api_key="YOUR_API_KEY", api_secret="YOUR_API_SECRET")

screenshot_url = urlbox_client.generate_url({"url": "http://example.com/"})
```

In your html template
```python
<img src="{{  screenshot_url }}"/>
```

#### Screenshots
Updated ReadMe: (with the new method use at the top of the page):

![image](https://user-images.githubusercontent.com/1453680/144045629-ebd61d51-830f-4cfc-9ea7-2432d7d346bd.png)

----