### PR TITLE
Exclude config files from the code coverage reports.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,9 +9,6 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: '3.7'
-    ignore:
-    - "conftest.py"
-    - "setup.py"
     steps:
     - uses: actions/checkout@main
     - name: Setup Python

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+    - 'conftest.py'
+    - 'setup.py'


### PR DESCRIPTION
#### What's this PR do?
Excludes config files from the code coverage reports.

Using a codecov.yml file this time.

Follow up to this work #47 

