### PR TITLE
Do not url encode options when making a get request.

### DIFF
--- a/urlbox/urlbox_client.py
+++ b/urlbox/urlbox_client.py
@@ -117,7 +117,7 @@ class UrlboxClient:
                 "Missing api_secret when initialising client. Required for authorised post request."
             )
 
-        processed_options, _ = self._process_options(options)
+        processed_options, _ = self._process_options_post_request(options)
 
         return requests.post(
             f"{self.base_api_url}{self.POST_END_POINT}",
@@ -126,7 +126,7 @@ class UrlboxClient:
                 "Authorization": f"Bearer {self.api_secret}",
             },
             allow_redirects=True,
-            json=json.loads(json.dumps(processed_options)),
+            json=processed_options,
             timeout=5,
         )
 
@@ -179,7 +179,7 @@ class UrlboxClient:
         else:
             return url
 
-    def _process_options(self, options):
+    def _process_options(self, options, url_encode_options=True):
         self._raise_key_error_if_missing_required_keys(options)
 
         processed_options = options.copy()
@@ -192,7 +192,16 @@ class UrlboxClient:
         format = processed_options.get("format", "png")
         processed_options["format"] = format
 
-        return urllib.parse.urlencode(processed_options, doseq=True), format
+        if url_encode_options:
+            return (
+                urllib.parse.urlencode(processed_options, doseq=True),
+                format,
+            )
+        else:
+            return processed_options, format
+
+    def _process_options_post_request(self, options):
+        return self._process_options(options, False)
 
     def _process_url(self, url):
         url_stripped = url.strip()


### PR DESCRIPTION
#### What's this PR do?
Do not url encode options when making a get request.

#### Background context
This is something taken from the ruby gem version of this library.

The need to play around with json loads and dumps was an attempt to
deal with the url encoded string of options being marshalled into a json
array for the post request body.

Now we are using the options dictionary as is, it doesn't need the json
marshalling anymore.

Somewhere along the line the post function broke due to the json
marshalling.

